### PR TITLE
Add a build action for FreeBSD binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -351,13 +351,14 @@ jobs:
         with:
           envs: 'ROBBOT_PASS'
           usesh: true
+          mem: 2048
           prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
           run: |
             set -ex
             opam init # --disable-sandboxing
             opam update
             opam pin add haxe . --no-action
-            opam install haxe --deps-only
+            opam install haxe --deps-only -y
             opam list
             ocamlopt -v
             eval $(opam env)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -346,10 +346,8 @@ jobs:
       - name: Build in FreeBSD VM
         id: build
         uses: vmactions/freebsd-vm@v0.1.3
-        env:
-          ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
         with:
-          envs: 'ROBBOT_PASS OPAMYES'
+          envs: 'OPAMYES'
           usesh: true
           mem: 2048
           prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
@@ -362,7 +360,7 @@ jobs:
             opam list
             ocamlopt -v
             eval $(opam env)
-            opam config exec -- make -s -j3 STATICLINK=1 haxe
+            gmake -s -j3 STATICLINK=1 haxe
             ldd -v ./haxe
       
       - name: Get haxe_bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -325,3 +325,59 @@ jobs:
         env:
           ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
       
+
+  freebsd-build:
+    runs-on: macos-latest
+    env:
+      PLATTFORM: freebsd64
+      OPAMYES: 1
+    steps:
+      - uses: actions/checkout@main
+        with:
+          submodules: recursive
+
+      - name: Apply dune patch for FreeBSD
+        run: git apply extra/github-actions/patches/dune.patch
+      
+      - name: Set ADD_REVISION=1 for non-release
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
+      
+      - name: Build in FreeBSD VM
+        id: build
+        uses: vmactions/freebsd-vm@v0.1.3
+        env:
+          ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
+        with:
+          envs: 'ROBBOT_PASS'
+          usesh: true
+          prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
+          run: |
+            set -ex
+            opam init # --disable-sandboxing
+            opam update
+            opam pin add haxe . --no-action
+            opam install haxe --deps-only
+            opam list
+            ocamlopt -v
+            eval $(opam env)
+            opam config exec -- make -s -j`nproc` STATICLINK=1 haxe
+            ldd -v ./haxe
+      
+      - name: Get haxe_bin
+        run: git clone https://github.com/Kode/haxe_bin.git
+      - name: Copy binary
+        run: cp ./haxe haxe_bin/haxe-freebsd
+      - name: Set name
+        run: git config --global user.name "Robbot"
+      - name: Set email
+        run: git config --global user.email "robbot2019@robdangero.us"
+      - name: Commit binary
+        run: git -C haxe_bin commit -a -m "Update FreeBSD binary to $GITHUB_SHA."
+      - name: Tag binary
+        run: git -C haxe_bin tag linux_$GITHUB_SHA
+      - name: Push binary
+        run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags
+        env:
+          ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
+      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,6 +371,8 @@ jobs:
         run: git config --global user.name "Robbot"
       - name: Set email
         run: git config --global user.email "robbot2019@robdangero.us"
+      - name: Add binary
+        run: git -C haxe_bin add -A
       - name: Commit binary
         run: git -C haxe_bin commit -a -m "Update FreeBSD binary to $GITHUB_SHA."
       - name: Tag binary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -349,7 +349,7 @@ jobs:
         env:
           ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
         with:
-          envs: 'ROBBOT_PASS'
+          envs: 'ROBBOT_PASS OPAMYES'
           usesh: true
           mem: 2048
           prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
@@ -358,11 +358,11 @@ jobs:
             opam init # --disable-sandboxing
             opam update
             opam pin add haxe . --no-action
-            opam install haxe --deps-only -y
+            opam install haxe --deps-only
             opam list
             ocamlopt -v
             eval $(opam env)
-            opam config exec -- make -s -j`nproc` STATICLINK=1 haxe
+            opam config exec -- make -s -j3 STATICLINK=1 haxe
             ldd -v ./haxe
       
       - name: Get haxe_bin

--- a/extra/github-actions/build-freebsd.yml
+++ b/extra/github-actions/build-freebsd.yml
@@ -8,10 +8,8 @@
 - name: Build in FreeBSD VM
   id: build
   uses: vmactions/freebsd-vm@v0.1.3
-  env:
-    ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
   with:
-    envs: 'ROBBOT_PASS OPAMYES'
+    envs: 'OPAMYES'
     usesh: true
     mem: 2048
     prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
@@ -24,7 +22,7 @@
       opam list
       ocamlopt -v
       eval $(opam env)
-      opam config exec -- make -s -j3 STATICLINK=1 haxe
+      gmake -s -j3 STATICLINK=1 haxe
       ldd -v ./haxe
 
 - name: Get haxe_bin

--- a/extra/github-actions/build-freebsd.yml
+++ b/extra/github-actions/build-freebsd.yml
@@ -13,13 +13,14 @@
   with:
     envs: 'ROBBOT_PASS'
     usesh: true
+    mem: 2048
     prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
     run: |
       set -ex
       opam init # --disable-sandboxing
       opam update
       opam pin add haxe . --no-action
-      opam install haxe --deps-only
+      opam install haxe --deps-only -y
       opam list
       ocamlopt -v
       eval $(opam env)

--- a/extra/github-actions/build-freebsd.yml
+++ b/extra/github-actions/build-freebsd.yml
@@ -1,0 +1,44 @@
+- name: Apply dune patch for FreeBSD
+  run: git apply extra/github-actions/patches/dune.patch
+
+- name: Set ADD_REVISION=1 for non-release
+  if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  run: echo "ADD_REVISION=1" >> $GITHUB_ENV
+
+- name: Build in FreeBSD VM
+  id: build
+  uses: vmactions/freebsd-vm@v0.1.3
+  env:
+    ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
+  with:
+    envs: 'ROBBOT_PASS'
+    usesh: true
+    prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
+    run: |
+      set -ex
+      opam init # --disable-sandboxing
+      opam update
+      opam pin add haxe . --no-action
+      opam install haxe --deps-only
+      opam list
+      ocamlopt -v
+      eval $(opam env)
+      opam config exec -- make -s -j`nproc` STATICLINK=1 haxe
+      ldd -v ./haxe
+
+- name: Get haxe_bin
+  run: git clone https://github.com/Kode/haxe_bin.git
+- name: Copy binary
+  run: cp ./haxe haxe_bin/haxe-freebsd
+- name: Set name
+  run: git config --global user.name "Robbot"
+- name: Set email
+  run: git config --global user.email "robbot2019@robdangero.us"
+- name: Commit binary
+  run: git -C haxe_bin commit -a -m "Update FreeBSD binary to $GITHUB_SHA."
+- name: Tag binary
+  run: git -C haxe_bin tag linux_$GITHUB_SHA
+- name: Push binary
+  run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags
+  env:
+    ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}

--- a/extra/github-actions/build-freebsd.yml
+++ b/extra/github-actions/build-freebsd.yml
@@ -38,7 +38,7 @@
 - name: Commit binary
   run: git -C haxe_bin commit -a -m "Update FreeBSD binary to $GITHUB_SHA."
 - name: Tag binary
-  run: git -C haxe_bin tag linux_$GITHUB_SHA
+  run: git -C haxe_bin tag freebsd_$GITHUB_SHA
 - name: Push binary
   run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags
   env:

--- a/extra/github-actions/build-freebsd.yml
+++ b/extra/github-actions/build-freebsd.yml
@@ -33,6 +33,8 @@
   run: git config --global user.name "Robbot"
 - name: Set email
   run: git config --global user.email "robbot2019@robdangero.us"
+- name: Add binary
+  run: git -C haxe_bin add -A
 - name: Commit binary
   run: git -C haxe_bin commit -a -m "Update FreeBSD binary to $GITHUB_SHA."
 - name: Tag binary

--- a/extra/github-actions/build-freebsd.yml
+++ b/extra/github-actions/build-freebsd.yml
@@ -11,7 +11,7 @@
   env:
     ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
   with:
-    envs: 'ROBBOT_PASS'
+    envs: 'ROBBOT_PASS OPAMYES'
     usesh: true
     mem: 2048
     prepare: pkg install -y ocaml ocaml-opam p5-string-shellquote p5-IPC-System-Simple pkgconf neko pcre gmake lzlib
@@ -20,11 +20,11 @@
       opam init # --disable-sandboxing
       opam update
       opam pin add haxe . --no-action
-      opam install haxe --deps-only -y
+      opam install haxe --deps-only
       opam list
       ocamlopt -v
       eval $(opam env)
-      opam config exec -- make -s -j`nproc` STATICLINK=1 haxe
+      opam config exec -- make -s -j3 STATICLINK=1 haxe
       ldd -v ./haxe
 
 - name: Get haxe_bin

--- a/extra/github-actions/patches/dune.patch
+++ b/extra/github-actions/patches/dune.patch
@@ -1,0 +1,13 @@
+diff --git a/dune b/dune
+index 2ac21fc49..8bc5065ed 100644
+--- a/dune
++++ b/dune
+@@ -1 +1,7 @@
++(env
++        (release
++                (ocamlopt_flags (:standard -ccopt -L/usr/local/lib))
++                (c_flags ("-I/usr/local/include"))
++        )
++)
+ (data_only_dirs extra lib std tests)
+\ No newline at end of file

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -59,3 +59,15 @@ jobs:
 
       @import install-neko.yml
       @import build-mac.yml
+
+  freebsd-build:
+    runs-on: macos-latest
+    env:
+      PLATTFORM: freebsd64
+      OPAMYES: 1
+    steps:
+      - uses: actions/checkout@main
+        with:
+          submodules: recursive
+
+      @import build-freebsd.yml


### PR DESCRIPTION
Extends the actions to include a FreeBSD binary build. This is being done using [this action](https://github.com/marketplace/actions/freebsd-vm?version=v0.1.3), running the build inside that VM and then adding the generated binary to the binaries repository.