### PR TITLE
Only commit when necessary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -499,12 +499,17 @@ jobs:
         run: git config --global user.name "Robbot"
       - name: Set email
         run: git config --global user.email "robbot2019@robdangero.us"
+      - name: Is commit needed?
+        run: |
+          [[ `git -C haxe_bin status --porcelain` ]] && echo "NEEDCOMMIT=1" >> $GITHUB_ENV || echo "No changes to repository"
       - name: Commit binary
-        run: git -C haxe_bin commit -a -m "Update Linux-ARM binary to $GITHUB_SHA."
+        run: |
+          [[ $NEEDCOMMIT ]] && git -C haxe_bin commit -a -m "Update Linux-$BUILDARCH binary to $GITHUB_SHA." || echo "No commit necessary"
       - name: Tag binary
-        run: git -C haxe_bin tag linux$BUILDARCH-$GITHUB_SHA && echo "Using tag 'linux$BUILDARCH-$GITHUB_SHA'"
+        run: |
+          [[ $NEEDCOMMIT ]] && git -C haxe_bin tag linux$BUILDARCH-$GITHUB_SHA || echo "No commit necessary"
       - name: Push binary
-        run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags || echo "Push binary only works on the original repo"
+        run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags || "WARNING! Push binary failed. This is supposed to fail on forked repositories."
         env:
           ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}
       

--- a/extra/github-actions/build-linux-arm.yml
+++ b/extra/github-actions/build-linux-arm.yml
@@ -94,11 +94,16 @@
   run: git config --global user.name "Robbot"
 - name: Set email
   run: git config --global user.email "robbot2019@robdangero.us"
+- name: Is commit needed?
+  run: |
+    [[ `git -C haxe_bin status --porcelain` ]] && echo "NEEDCOMMIT=1" >> $GITHUB_ENV || echo "No changes to repository"
 - name: Commit binary
-  run: git -C haxe_bin commit -a -m "Update Linux-ARM binary to $GITHUB_SHA."
+  run: |
+    [[ $NEEDCOMMIT ]] && git -C haxe_bin commit -a -m "Update Linux-$BUILDARCH binary to $GITHUB_SHA." || echo "No commit necessary"
 - name: Tag binary
-  run: git -C haxe_bin tag linux$BUILDARCH-$GITHUB_SHA && echo "Using tag 'linux$BUILDARCH-$GITHUB_SHA'"
+  run: |
+    [[ $NEEDCOMMIT ]] && git -C haxe_bin tag linux$BUILDARCH-$GITHUB_SHA || echo "No commit necessary"
 - name: Push binary
-  run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags || echo "Push binary only works on the original repo"
+  run: git -C haxe_bin push https://Kode-Robbot:$ROBBOT_PASS@github.com/Kode/haxe_bin.git master --tags || "WARNING! Push binary failed. This is supposed to fail on forked repositories."
   env:
     ROBBOT_PASS: ${{ secrets.ROBBOT_PASS }}


### PR DESCRIPTION
Since jobs executed in a matrix are automatically aborted if one entry of the job matrix fails, it is necessary that the commit, tag and push binary actions don't fail, but instead output a warning.